### PR TITLE
Revert "chore(deps): pin dependency eslint to 9.16.0"

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "eslint": "9.16.0"
+    "eslint": "^9.0.0"
   },
   "dependencies": {
     "@eslint/compat": "1.2.3",


### PR DESCRIPTION
Reverts pixiv/frontend-config#25

We should not pin peerDeps..